### PR TITLE
Do not run tests since they are not compiled

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -49,8 +49,6 @@ check() {
   cd "${srcdir}/${pkgname}"
 
   "${srcdir}"/build/src/contour/contour version
-  "${srcdir}"/build/src/crispy/crispy_test
-  "${srcdir}"/build/src/vtbackend/vtbackend_test
 }
 
 package() {


### PR DESCRIPTION
Fix ArchLinux github actions since we do not build tests in contour-aur package
If we want to compile unit tests this requires additional dependencies that are not essential and therefore i think should not be included 